### PR TITLE
Replace 3rd-party diff_match_patch with our DMP

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -7,7 +7,7 @@ const async = require("async");
 const log = require("floorine");
 const mime = require("mime-types");
 const DMP = require("native-diff-match-patch");
-const Diff_Match_Patch = require("diff_match_patch").diff_match_patch;
+const Diff_Match_Patch = require("dmp");
 const JS_DMP = new Diff_Match_Patch();
 const _ = require("lodash");
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "async": "1.x",
     "basic-auth": "1.x",
     "body-parser": "1.13.x",
-    "diff_match_patch": "0.1.x",
+    "dmp": "0.x",
     "express": "4.x",
     "fleece": "0.x",
     "floorine": "0.3.x",

--- a/tests/mock.js
+++ b/tests/mock.js
@@ -5,8 +5,8 @@ const util = require("util");
 
 const log = require("floorine");
 const DMP = require("native-diff-match-patch");
-// const diff_match_patch = require('diff_match_patch');
-// const DMP = new diff_match_patch.diff_match_patch();
+// const Diff_Match_Patch = require("dmp");
+// const DMP = new Diff_Match_Patch();
 const _ = require("lodash");
 
 const AgentHandler = require("../lib/handler/agent");


### PR DESCRIPTION
This replaces the abandoned [`diff_match_patch`](https://github.com/ForbesLindesay/diff-match-patch) with with our [`dmp`](https://github.com/Floobits/dmp).

Our version has working tests and is updated to use lots of es6 fanciness. Also, it will soon have fixed any potentially-throwing calls to `encodeURI()` and friends.
